### PR TITLE
Bug while hover on disabled buttons

### DIFF
--- a/_assets/stylesheets/_custom.sass
+++ b/_assets/stylesheets/_custom.sass
@@ -62,8 +62,9 @@ button
           -webkit-transform: translateY(0px)
           -moz-transform: translateY(0px)
           transform: translateY(0px)
+          opacity: 0
       &::after
-        background: #333
+        background: none
         border-radius: 5px
         bottom: -30px
         font-size: 12px


### PR DESCRIPTION
The disabled buttons in challenges showed a scroll bar while hovering them.
I just changed the opacity to '0' for that scroll bar.